### PR TITLE
[Feat]: Add 'concatKeys' to all modules 

### DIFF
--- a/src/Candid/lib.mo
+++ b/src/Candid/lib.mo
@@ -17,6 +17,7 @@ import Parser "Text/Parser";
 import ToText "Text/ToText";
 
 import T "Types";
+import Utils "../Utils";
 
 
 module {
@@ -34,5 +35,8 @@ module {
     };
 
     public let { toText } = ToText;
+
+    public let concatKeys = Utils.concatKeys;
+
 
 };

--- a/src/JSON/lib.mo
+++ b/src/JSON/lib.mo
@@ -5,6 +5,7 @@ import JSON "mo:json/JSON";
 import Candid "../Candid";
 import FromText "FromText";
 import ToText "ToText";
+import Utils "../Utils";
 
 module {
     public type JSON = JSON.JSON;
@@ -13,4 +14,5 @@ module {
 
     public let { toText; fromCandid } = ToText;
 
+    public let concatKeys = Utils.concatKeys;
 };

--- a/src/UrlEncoded/lib.mo
+++ b/src/UrlEncoded/lib.mo
@@ -4,9 +4,12 @@ import Candid "../Candid";
 import FromText "./FromText";
 import ToText "./ToText";
 
+import Utils "../Utils";
 module {
     public let { fromText; toCandid } = FromText;
 
     public let { toText; fromCandid } = ToText;
+
+    public let concatKeys = Utils.concatKeys;
 
 };

--- a/src/Utils.mo
+++ b/src/Utils.mo
@@ -6,13 +6,19 @@ import Iter "mo:base/Iter";
 import Result "mo:base/Result";
 
 import Prelude "mo:base/Prelude";
-import itertools "mo:itertools/Iter";
+import Itertools "mo:itertools/Iter";
 
 module {
 
     type Iter<A> = Iter.Iter<A>;
     type Result<A, B> = Result.Result<A, B>;
 
+    public func concatKeys(keys : [[Text]]) : [Text] {
+        Iter.toArray(
+            Itertools.flattenArray(keys)
+        )
+    };
+    
     public func sized_iter_to_array<A>(iter: Iter<A>, size: Nat): [A] {
         Array.tabulate<A>(
             size,
@@ -33,9 +39,9 @@ module {
     };
 
     public func subText(text : Text, start : Nat, end : Nat) : Text {
-        itertools.toText(
-            itertools.skip(
-                itertools.take(text.chars(), end),
+        Itertools.toText(
+            Itertools.skip(
+                Itertools.take(text.chars(), end),
                 start,
             ),
         );

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -6,6 +6,7 @@ import CandidTypes "Candid/Types";
 import UrlEncodedModule "UrlEncoded";
 import JsonModule "JSON";
 import CandidModule "Candid";
+import Utils "Utils";
 
 module {
 
@@ -17,9 +18,5 @@ module {
     public let JSON = JsonModule;
     public let URLEncoded = UrlEncodedModule;
 
-    public func concatKeys(keys : [[Text]]) : [Text] {
-        Iter.toArray(
-            Itertools.flattenArray(keys)
-        )
-    };
+    public let concatKeys = Utils.concatKeys;
 }


### PR DESCRIPTION
Add 'concatKeys' to all modules to help concatenate datatype keys for encoding and mapping key hashes to their plaintext names