### PR TITLE
fix: propagate recursive_types_map through build_compound_type/build_types (DeBruijn index bookkeeping)

### DIFF
--- a/src/Candid/Blob/Decoder.mo
+++ b/src/Candid/Blob/Decoder.mo
@@ -347,8 +347,9 @@ module {
         Array.tabulate(total_compound_types, extract_compound_type);
     };
 
-    func build_compound_type(compound_types : [ShallowCandidTypes], start_pos : Nat, recursive_types_map : Map<Nat, CandidType>) : CandidType {
-        func _build_compound_type(compound_types : [ShallowCandidTypes], start_pos : Nat, visited : Set<Nat>, is_recursive_set : Set<Nat>, recursive_types_map : Map<Nat, CandidType>) : CandidType {
+    func build_compound_type(compound_types : [ShallowCandidTypes], start_pos : Nat, recursive_types_map_param : Map<Nat, CandidType>) : (CandidType, Map<Nat, CandidType>) {
+        var recursive_types_map = recursive_types_map_param;
+        func _build_compound_type(compound_types : [ShallowCandidTypes], start_pos : Nat, visited : Set<Nat>, is_recursive_set : Set<Nat>) : CandidType {
             var pos = start_pos;
 
             func resolve_field_types((field_key, ref_pos) : (Text, Nat)) : ((Text, CandidType)) {
@@ -356,7 +357,7 @@ module {
                 let resolved_type : CandidType = if (is_code_primitive_type(Nat8.fromNat(ref_pos))) {
                     code_to_primitive_type(Nat8.fromNat(ref_pos));
                 } else {
-                    _build_compound_type(compound_types, ref_pos, visited, is_recursive_set, recursive_types_map);
+                    _build_compound_type(compound_types, ref_pos, visited, is_recursive_set);
                 };
 
                 while (Set.size(visited) > visited_size) {
@@ -383,7 +384,7 @@ module {
                     let ref_type = if (is_code_primitive_type(Nat8.fromNat(ref_pos))) {
                         code_to_primitive_type(Nat8.fromNat(ref_pos));
                     } else {
-                        _build_compound_type(compound_types, ref_pos, visited, is_recursive_set, recursive_types_map);
+                        _build_compound_type(compound_types, ref_pos, visited, is_recursive_set);
                     };
 
                     #Option(ref_type);
@@ -392,7 +393,7 @@ module {
                     let ref_type = if (is_code_primitive_type(Nat8.fromNat(ref_pos))) {
                         code_to_primitive_type(Nat8.fromNat(ref_pos));
                     } else {
-                        _build_compound_type(compound_types, ref_pos, visited, is_recursive_set, recursive_types_map);
+                        _build_compound_type(compound_types, ref_pos, visited, is_recursive_set);
                     };
                     #Array(ref_type);
                 };
@@ -416,11 +417,13 @@ module {
         let visited = Set.new<Nat>();
         let is_recursive_set = Set.new<Nat>();
 
-        _build_compound_type(compound_types, start_pos, visited, is_recursive_set, recursive_types_map);
+        let result_type = _build_compound_type(compound_types, start_pos, visited, is_recursive_set);
+        (result_type, recursive_types_map);
     };
 
-    public func build_types(bytes : Blob, state : [var Nat], compound_types : [ShallowCandidTypes], recursive_types_map : Map<Nat, CandidType>) : [CandidType] {
+    public func build_types(bytes : Blob, state : [var Nat], compound_types : [ShallowCandidTypes], recursive_types_map_param : Map<Nat, CandidType>) : ([CandidType], Map<Nat, CandidType>) {
         let total_candid_types = decode_leb128(bytes, state);
+        var recursive_types_map = recursive_types_map_param;
 
         let candid_types = Array.tabulate(
             total_candid_types,
@@ -432,7 +435,8 @@ module {
                     primitive_type;
                 } else {
                     let start_pos = decode_leb128(bytes, state);
-                    let compound_type = build_compound_type(compound_types, start_pos, recursive_types_map);
+                    let (compound_type, updated_map) = build_compound_type(compound_types, start_pos, recursive_types_map);
+                    recursive_types_map := updated_map;
                     compound_type;
                 };
 
@@ -441,7 +445,7 @@ module {
             },
         );
 
-        (candid_types);
+        (candid_types, recursive_types_map);
     };
 
     public func skip_compound_types(bytes : Blob, state : [var Nat], total_compound_types : Nat) {
@@ -520,13 +524,15 @@ module {
             return #err("Invalid Magic Number");
         };
 
-        let recursive_types_map = Map.new<Nat, CandidType>();
+        var recursive_types_map = Map.new<Nat, CandidType>();
 
         if (not is_types_set) {
             // extract types from blob
             let total_compound_types = decode_leb128(bytes, state);
             let compound_types = extract_compound_types(bytes, state, total_compound_types, record_key_map);
-            candid_types := build_types(bytes, state, compound_types, recursive_types_map);
+            let (types, updated_recursive_map) = build_types(bytes, state, compound_types, recursive_types_map);
+            candid_types := types;
+            recursive_types_map := updated_recursive_map;
 
         } else {
             // types are set but 'blob_contains_only_values' is not set,

--- a/src/Candid/Blob/TypedSerializer.mo
+++ b/src/Candid/Blob/TypedSerializer.mo
@@ -383,8 +383,8 @@ module TypedSerializer {
 
         let total_compound_types = decode_leb128(bytes, state);
         let compound_types = Decoder.extract_compound_types(bytes, state, total_compound_types, record_key_map);
-        let recursive_types_map = Map.new<Nat, CandidType>();
-        let extracted_candid_types = Decoder.build_types(bytes, state, compound_types, recursive_types_map);
+        let initial_recursive_types_map = Map.new<Nat, CandidType>();
+        let (extracted_candid_types, recursive_types_map) = Decoder.build_types(bytes, state, compound_types, initial_recursive_types_map);
 
         let type_header_size = state[C.BYTES_INDEX];
         let encoded_type_header = Array.tabulate(type_header_size, func(i : Nat) : Nat8 = blob.get(i));

--- a/tests/helpers/motoko_candid_utils.mo
+++ b/tests/helpers/motoko_candid_utils.mo
@@ -101,7 +101,7 @@ module {
                 )
             );
             case (unsupported) {
-                Runtime.trap("toArgeType(): Unsupported type " # debug_show unsupported);
+                Runtime.trap("toArgType(): Unsupported type " # debug_show unsupported);
             };
         };
     };


### PR DESCRIPTION
Note: Please read my comment below first. I don't think that there is a bug, but let's check. AI pretty much figured it out when I told it to construct a testcase that passes with this patch but fails without. It detected that the "bug" was masked by the imperative nature of the used `Map`. It is quite clear why.

## Summary

- `build_compound_type` now returns `(CandidType, Map<Nat, CandidType>)` instead of just `CandidType`, so the updated `recursive_types_map` is explicitly threaded back to the caller.
- `build_types` now returns `([CandidType], Map<Nat, CandidType>)` and accumulates the map across multiple `build_compound_type` calls.
- The inner `_build_compound_type` closes over a `var recursive_types_map` instead of receiving it as a shadowed parameter — removing an aliasing hazard that would silently break if the underlying map implementation were ever changed to immutable (e.g., `mo:core/pure/Map`).
- Fixes typo in `tests/helpers/motoko_candid_utils.mo`: `toArgeType()` → `toArgType()` in a `Runtime.trap` message.

## Background

This fix originates from ggreif's closed PR #42 ("chore: port to Motoko `core` library"), specifically commit `0be3248`. During that port, the code temporarily used `mo:core/pure/Map` (an immutable map), which made the propagation bug immediately visible: `PureMap.add` returns a new map that was discarded at each call site, so `decode_candid_values` received an empty `recursive_types_map` and would `Runtime.trap("Recursive type not found")` on any `#Recursive(N)` type reference.

The current `main` uses `mo:map@9.0` (mutable), which happens to paper over the bug via shared-reference mutation — but the API contract is still wrong: the caller of `build_types` cannot rely on side-effects to a map that was passed in, and the code is fragile to any future map-mutability change. Making the propagation explicit is the correct fix.

## Test plan

- [ ] All existing tests pass: `npx ic-mops test` (verified locally — 43 tests pass including the "recursive types" suite in `Candid.Test.mo`)
- [ ] Confirm `build_compound_type` and `build_types` compile cleanly with updated return types in both `Decoder.mo` and `TypedSerializer.mo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)