### PR TITLE
fix(JSON/ToText): escape \\, control chars in #Text values (RFC 8259 §7)

### DIFF
--- a/src/JSON/ToText.mo
+++ b/src/JSON/ToText.mo
@@ -1,4 +1,6 @@
 import Buffer "mo:base@0.16/Buffer";
+import Char "mo:core@2.4/Char";
+import Nat32 "mo:core@2.4/Nat32";
 import Result "mo:core@2.4/Result";
 import Text "mo:core@2.4/Text";
 
@@ -14,6 +16,38 @@ module {
     type JSON = JSON.JSON;
     type Candid = Candid.Candid;
     type Result<A, B> = Result.Result<A, B>;
+
+    // Escape a Text value for inclusion in a JSON string literal,
+    // per RFC 8259 §7. Order matters: backslash MUST be escaped
+    // first — every later replacement emits a `\`, and a final
+    // backslash pass would re-double those new backslashes.
+    func escapeJSONString(s : Text) : Text {
+        let chained =
+            Text.replace(s, #text "\\", "\\\\")
+            |> Text.replace(_, #text "\"", "\\\"")
+            |> Text.replace(_, #text "\n", "\\n")
+            |> Text.replace(_, #text "\r", "\\r")
+            |> Text.replace(_, #text "\t", "\\t")
+            |> Text.replace(_, #text "\u{08}", "\\b")
+            |> Text.replace(_, #text "\u{0c}", "\\f");
+        // Remaining U+0000..U+001F (minus the named ones above) → \u00XX.
+        let buf = Buffer.Buffer<Char>(chained.size());
+        let hex = Text.toArray("0123456789abcdef");
+        for (c in chained.chars()) {
+            let n = Char.toNat32(c);
+            if (n < 0x20) {
+                buf.add('\\');
+                buf.add('u');
+                buf.add('0');
+                buf.add('0');
+                buf.add(hex[Nat32.toNat(n / 16)]);
+                buf.add(hex[Nat32.toNat(n % 16)]);
+            } else {
+                buf.add(c);
+            };
+        };
+        Text.fromIter(buf.vals())
+    };
 
     /// Converts serialized Candid blob to JSON text
     public func toText(blob : Blob, keys : [Text], options : ?CandidType.Options) : Result<Text, Text> {
@@ -37,7 +71,7 @@ module {
         let json : JSON = switch (candid) {
             case (#Null) #Null;
             case (#Bool(n)) #Boolean(n);
-            case (#Text(n)) #String(Text.replace(n, #text("\""), ("\\\"")));
+            case (#Text(n)) #String(escapeJSONString(n));
 
             case (#Int(n)) #Number(n);
             case (#Int8(n)) #Number(IntX.from8ToInt(n));

--- a/tests/JSONStringEscape.test.mo
+++ b/tests/JSONStringEscape.test.mo
@@ -1,0 +1,112 @@
+// @testmode wasi
+import Debug "mo:core@2.4/Debug";
+import Text "mo:core@2.4/Text";
+
+import { test; suite } "mo:test";
+
+import { JSON } "../src";
+
+// `expectEncode` asserts the exact wire bytes produced by
+// `JSON.fromCandid(#Text payload)`. Used for every escape category.
+//
+// `roundTrip` additionally re-parses the encoded form and asserts the
+// original Text is restored. We use it only for escape forms the
+// underlying JSON parser is known to support out of the box (named
+// short-forms `\b \f \n \r \t \" \\`, plus literal pass-through of
+// printable ASCII). The `\u00XX` fallback for unnamed control chars
+// U+0000..U+001F is exercised by `expectEncode` only — round-tripping
+// those depends on a separate parser-side `\u` handling improvement.
+func expectEncode(name : Text, payload : Text, expectedWire : Text) {
+    test(
+        name,
+        func() {
+            let encoded = switch (JSON.fromCandid(#Text payload)) {
+                case (#ok t) t;
+                case (#err e) {
+                    Debug.print("encode failed: " # e);
+                    assert false;
+                    return;
+                };
+            };
+            if (encoded != expectedWire) {
+                Debug.print("encode wire mismatch:");
+                Debug.print("  expected: " # expectedWire);
+                Debug.print("  actual:   " # encoded);
+                assert false;
+            };
+        },
+    );
+};
+
+func roundTrip(name : Text, payload : Text, expectedWire : Text) {
+    test(
+        name,
+        func() {
+            let encoded = switch (JSON.fromCandid(#Text payload)) {
+                case (#ok t) t;
+                case (#err e) {
+                    Debug.print("encode failed: " # e);
+                    assert false;
+                    return;
+                };
+            };
+            if (encoded != expectedWire) {
+                Debug.print("encode wire mismatch:");
+                Debug.print("  expected: " # expectedWire);
+                Debug.print("  actual:   " # encoded);
+                assert false;
+            };
+            let decoded = switch (JSON.toCandid(encoded)) {
+                case (#ok(#Text t)) t;
+                case (#ok other) {
+                    Debug.print("decode wrong shape: " # debug_show other);
+                    assert false;
+                    return;
+                };
+                case (#err e) {
+                    Debug.print("decode failed: " # e);
+                    assert false;
+                    return;
+                };
+            };
+            if (decoded != payload) {
+                Debug.print("round-trip mismatch:");
+                Debug.print("  original:  " # payload);
+                Debug.print("  decoded:   " # decoded);
+                assert false;
+            };
+        },
+    );
+};
+
+suite(
+    "JSON string-escape (encoder side, RFC 8259 §7)",
+    func() {
+        // Named short-forms — round-trip with the existing parser.
+        roundTrip("backslash", "a\\b", "\"a\\\\b\"");
+        roundTrip("double-quote", "a\"b", "\"a\\\"b\"");
+        roundTrip("newline", "a\nb", "\"a\\nb\"");
+        roundTrip("carriage return", "a\rb", "\"a\\rb\"");
+        roundTrip("tab", "a\tb", "\"a\\tb\"");
+        roundTrip("backspace U+0008", "a\u{08}b", "\"a\\bb\"");
+        roundTrip("form feed U+000C", "a\u{0c}b", "\"a\\fb\"");
+        roundTrip(
+            "literal `\\n\\n` is not collapsed to two newlines",
+            "\\n\\n",
+            "\"\\\\n\\\\n\"",
+        );
+        roundTrip(
+            "OpenAI-style multi-line user content with backslash",
+            "Hello\nworld with a \\ slash",
+            "\"Hello\\nworld with a \\\\ slash\"",
+        );
+
+        // \u00XX fallback — encode-only. Round-trip needs a parser-side
+        // improvement that lives in a separate change.
+        expectEncode("NUL U+0000", "a\u{00}b", "\"a\\u0000b\"");
+        expectEncode("U+0001 (start-of-heading)", "a\u{01}b", "\"a\\u0001b\"");
+        expectEncode("U+001F (boundary, last control char)", "a\u{1f}b", "\"a\\u001fb\"");
+        // U+0020 (space) is NOT a control char and must NOT be escaped — round-trip is safe.
+        roundTrip("U+0020 (space, just above boundary)", "a b", "\"a b\"");
+    },
+);


### PR DESCRIPTION
## Bug

`JSON.fromCandid` only escapes `"` in `#Text` values via a single `Text.replace` at [`src/JSON/ToText.mo`](https://github.com/NatLabs/serde/blob/main/src/JSON/ToText.mo) (the `case (#Text(n))` arm). Any other character required by [RFC 8259 §7](https://datatracker.ietf.org/doc/html/rfc8259#section-7) — `\`, the named short-form controls (`\b \f \n \r \t`), and the rest of U+0000..U+001F — passes through unescaped. The resulting bytes are not valid JSON and are rejected by strict consumers.

Real-world hit: a Motoko canister calling OpenAI's HTTP API gets `HTTP 400 "we could not parse the JSON body"` whenever a user prompt contains a backslash, newline, or tab — extremely common in practice (any code-block or multi-line message).

## Fix

Replaces the partial `Text.replace` with a complete `escapeJSONString` helper that:

1. Doubles `\` **first** (load-bearing — every later replacement emits a `\`; doubling later would clobber the new ones).
2. Escapes `"`, then the named short-forms `\n \r \t \b \f` via further `Text.replace` calls (matches the existing `Text.replace`-chain idiom on the same line).
3. Falls back to `\u00XX` for the remaining U+0000..U+001F via a single `Buffer<Char>` pass.

`Text.toArray("0123456789abcdef")` is hoisted out of the per-char loop so the lookup table is built once.

## Tests

New `tests/JSONStringEscape.test.mo` with two helpers:

- `roundTrip(payload, wire)` — asserts encoded bytes match `wire` AND that the parser restores `payload`. Used for every named short-form, plus an adversarial case (`literal \n\n is not collapsed to two newlines`) and an OpenAI-style multi-line repro.
- `expectEncode(payload, wire)` — asserts encoded bytes only. Used for the `\u00XX` fallback (NUL, U+0001, U+001F) because round-tripping those depends on a parser-side improvement that lives in [aviate-labs/json.mo#8](https://github.com/aviate-labs/json.mo/pull/8) (separate, complementary). The boundary just-above (U+0020) round-trips fine and is included in the round-trip suite to lock the encoder boundary.

13 test cases total, all pass.

## Independent review

I had a separate agent re-review this before opening the PR. Verdict: **APPROVED**. The audit checked:

- **Order is right** — backslash doubled first; reversing breaks every later escape.
- **Codepoints match RFC §7** — `\b`=U+0008, `\f`=U+000C, `\n`=U+000A, `\r`=U+000D, `\t`=U+0009.
- **Boundary is exact** — `n < 0x20` escapes U+0000..U+001F, leaves U+0020 alone.
- **Non-ASCII passes through** — codepoints ≥ U+0080 hit the else arm; UTF-8 bytes are valid JSON inner content.
- **No double-escape risk** — `JSON.fromCandid` is the only producer of `#String` here; callers pass raw `Candid.#Text`.
- **`\u00XX` fallback hex is lower-case** (RFC permits either case; tests assert lower-case for determinism).

The reviewer also flagged a follow-up: `src/JSON/FromText.mo`'s `Text.replace(n, "\\\"", "\"")` is dead — the underlying parser collapses `\"` to `"` before that line ever runs. Out of scope here; mention as a separate cleanup.

## Out of scope

- `mops.toml` version bump — left for the maintainer to decide what to do (the upstream package is `serde@3.x`; not assuming a bump strategy).
- Round-tripping `\u00XX` payloads — depends on the parser-side improvement at [aviate-labs/json.mo#8](https://github.com/aviate-labs/json.mo/pull/8). Once that lands and the submodule pin updates, the three `expectEncode` cases can be promoted to `roundTrip`.